### PR TITLE
Factor in the reset event when determining game reset block

### DIFF
--- a/src/classes/Game.php
+++ b/src/classes/Game.php
@@ -4151,5 +4151,17 @@ class Game {
 			'game_id' => $this->db_game['game_id']
 		]);
 	}
+	
+	public function event_index_to_affected_block($event_index) {
+		$info = $this->blockchain->app->run_query("SELECT MIN(event_starting_block) FROM events WHERE game_id=:game_id AND event_index <= :event_index;", [
+			'event_index' => $event_index
+		]);
+		
+		if ($info->rowCount() > 0) {
+			$info = $info->fetch();
+			return (int) $info['MIN(event_starting_block)'];
+		}
+		else return false;
+	}
 }
 ?>

--- a/src/classes/GameDefinition.php
+++ b/src/classes/GameDefinition.php
@@ -294,6 +294,9 @@ class GameDefinition {
 			$log_message .= "Resetting events from #".$set_events_from_index."\n";
 			$game->reset_events_from_index($set_events_from_index);
 			
+			$events_earliest_affected_block = $game->event_index_to_affected_block($set_events_from_index);
+			$reset_block = $game->blockchain->app->min_excluding_false([$reset_block, $events_earliest_affected_block]);
+			
 			$set_events_from_pos = $set_events_from_index-$event_array_pos_to_index_offset;
 			
 			if (!is_numeric($reset_block)) $reset_block = $new_game_obj['events'][$set_events_from_pos]->event_starting_block;


### PR DESCRIPTION
This resolves a problem where bet event & option IDs don't get set correctly if events are not in chronological order.