### PR TITLE
Sending to burn address should burn coins even if addr has option index

### DIFF
--- a/src/models/Blockchain.php
+++ b/src/models/Blockchain.php
@@ -1289,7 +1289,7 @@ class Blockchain {
 								$payout_insert_q = "('".$color_game->db_game['game_id']."', 1, '".$payout_io_id."', '".$payout_address_id."', '".$game_out_index."', null, 0, null, 0, 0, 0, '".$option_id."', '".$color_game->db_game['default_contract_parts']."', '".$event->db_event['event_id']."', null, 0, ".$payout_is_resolved.", 1), ";
 								$game_out_index++;
 							}
-							else $insert_q .= "'".($gio_amount+$this_destroy_amount)."', 0, null, null, null, null, 0, 1, 1";
+							else $insert_q .= "'".$gio_amount."', '".$this_destroy_amount."', null, null, null, null, 0, 1, 1";
 						}
 						else $insert_q .= "'".$gio_amount."', '".$this_destroy_amount."', null, null, null, null, 0, 1, 1";
 						

--- a/src/models/Game.php
+++ b/src/models/Game.php
@@ -2466,7 +2466,7 @@ class Game {
 									$payout_insert_q = "('".$this->db_game['game_id']."', '".$payout_io_id."', '".$payout_address_id."', '".$game_out_index."', '".$game_io_index."', 1, 0, 0, '".$block_height."', '".$round_id."', 0, 0, '".$option_id."', '".$this->db_game['default_contract_parts']."', '".$events_by_option_id[$option_id]->db_event['event_id']."', null, 0, 0, ".$payout_is_resolved.", 1), ";
 									$game_out_index++;
 								}
-								else $insert_q .= "'".($gio_amount+$this_destroy_amount)."', 0, null, null, null, null, null, 0, 1, null";
+								else $insert_q .= "'".$gio_amount."', '".$this_destroy_amount."', null, null, null, null, null, 0, 1, null";
 							}
 							else $insert_q .= "'".$gio_amount."', '".$this_destroy_amount."', null, null, null, null, null, 0, 1, null";
 							


### PR DESCRIPTION
- Fixes behavior where sending game coins to burn address would not burn them depending on address option index.
- Need to fully reset all games after this protocol change to be on correct TXO set.